### PR TITLE
fix image-thumbnail functionality

### DIFF
--- a/run_aspace_do.rb
+++ b/run_aspace_do.rb
@@ -9,6 +9,7 @@ ALLOWED_USAGES = %w(audio-service video-service image-service image-thumbnail)
 DO_URI_FNAME   = 'archival_object_uri'
 HANDLE_FNAME   = 'handle'
 HANDLE_PREFIX  = 'http://hdl.handle.net/'
+THUMBNAIL_URL_APPEND = '?urlappend=/mode/thumb'
 
 #------------------------------------------------------------------------------
 # helper methods
@@ -21,6 +22,13 @@ def script_usage
 <<END_OF_USAGE
 Usage: $ ruby #{__FILE__} <file with directory list> <usage statement> <path-to-dir-root> 
   e.g., $ ruby #{__FILE__} nitrates.txt 'image-service' /path/to/wips/
+
+  Valid usage statements:
+  #{ALLOWED_USAGES.inject('') {|str, u| str << "#{u} "}}
+
+  Please note:
+  if the usage statement == 'image-thumbnail', the string '#{THUMBNAIL_URL_APPEND}' will 
+  automatically be appended to the handle url.
 
   Please note:
   you must specify the path the the aspace-do-update executable using
@@ -97,15 +105,16 @@ entries.each { |e|
   do_uri = do_uri.chomp
   handle = File.open("#{e}/#{HANDLE_FNAME}").first
   handle = handle.chomp
+  handle_url = HANDLE_PREFIX + handle + (usage == 'image-thumbnail' ? THUMBNAIL_URL_APPEND : '')
   key = File.basename(e)
-  do_info[key] = [do_uri, HANDLE_PREFIX + handle]
+  do_info[key] = [do_uri, handle_url]
 }
 
 do_info.each_pair { |k,v|
   puts "#{k}: #{v}"
   do_uri = v[0]
-  handle = v[1]
-  cmd = "#{updater_script} -a #{do_uri} -f #{handle} -u #{usage}"
+  handle_url = v[1]
+  cmd = "#{updater_script} -a #{do_uri} -f #{handle_url} -u #{usage}"
   puts cmd
   o, e, s = Open3.capture3(cmd)
   unless s.exitstatus == 0

--- a/test/run_aspace_do_test.rb
+++ b/test/run_aspace_do_test.rb
@@ -21,12 +21,26 @@ class RunAspaceDo < MiniTest::Test
     o, e, s = Open3.capture3(env, "#{COMMAND} #{OK_WIP_LIST_FILE} 'audio-service' #{OK_WIP_PATH}")
     assert(s.exitstatus == 0, "exit status: #{s.exitstatus}")
     o_array = o.split("\n")
-    assert('bar: ["bar-uri", "http://hdl.handle.net/bar-handle"]' == o_array[0]) 
+    assert('bar: ["bar-uri", "http://hdl.handle.net/bar-handle"]' == o_array[0])
     assert("#{env['RUN_ASPACE_DO_UPDATER_PATH']} -a bar-uri -f http://hdl.handle.net/bar-handle -u audio-service" == o_array[1])
-    assert('aspace-do-uri: success!' == o_array[2]) 
-    assert('foo: ["foo-uri", "http://hdl.handle.net/foo-handle"]' == o_array[3]) 
+    assert('aspace-do-uri: success!' == o_array[2])
+    assert('foo: ["foo-uri", "http://hdl.handle.net/foo-handle"]' == o_array[3])
     assert("#{env['RUN_ASPACE_DO_UPDATER_PATH']} -a foo-uri -f http://hdl.handle.net/foo-handle -u audio-service" == o_array[4])
-    assert('aspace-do-uri: success!' == o_array[5]) 
+    assert('aspace-do-uri: success!' == o_array[5])
+    assert(e == '')
+  end
+
+  def test_valid_invocation_for_thumbnails
+    env = {'RUN_ASPACE_DO_UPDATER_PATH' => 'test/mock_scripts/good-aspace-do-update'}
+    o, e, s = Open3.capture3(env, "#{COMMAND} #{OK_WIP_LIST_FILE} 'image-thumbnail' #{OK_WIP_PATH}")
+    assert(s.exitstatus == 0, "exit status: #{s.exitstatus}")
+    o_array = o.split("\n")
+    assert('bar: ["bar-uri", "http://hdl.handle.net/bar-handle?urlappend=/mode/thumb"]' == o_array[0])
+    assert("#{env['RUN_ASPACE_DO_UPDATER_PATH']} -a bar-uri -f http://hdl.handle.net/bar-handle?urlappend=/mode/thumb -u image-thumbnail" == o_array[1])
+    assert('aspace-do-uri: success!' == o_array[2])
+    assert('foo: ["foo-uri", "http://hdl.handle.net/foo-handle?urlappend=/mode/thumb"]' == o_array[3])
+    assert("#{env['RUN_ASPACE_DO_UPDATER_PATH']} -a foo-uri -f http://hdl.handle.net/foo-handle?urlappend=/mode/thumb -u image-thumbnail" == o_array[4])
+    assert('aspace-do-uri: success!' == o_array[5])
     assert(e == '')
   end
 end


### PR DESCRIPTION
Although the "image-thumbnail" usage statement was supported in
earlier versions of this script, the correct URLs would not have been
loaded into ArchivesSpace. This is because the publication
infrastructure assumes that image-thumbnail usage statement is bound
to a URL that includes a urlappend query.  e.g.,
http://hdl.handle.net/2333.1/foo?urlappend=/mode/thumb

This version of the script automatically appends the proper urlappend
string to the handle if the usage statement is 'image-thumbnail'.

ticket:
https://jira.nyu.edu/jira/browse/DLTSASPACE-19