### PR TITLE
add $stdout.flush

### DIFF
--- a/run_aspace_do.rb
+++ b/run_aspace_do.rb
@@ -136,6 +136,7 @@ do_info.each_pair { |k,v|
   pause_count += 1
   if (pause_count % PAUSE_EVERY_N_OBJECTS) == 0
     puts "#{pause_count}: pausing for #{PAUSE_DURATION_SECONDS} seconds..."
+    $stdout.flush
     sleep PAUSE_DURATION_SECONDS
   end
 }


### PR DESCRIPTION
## Overview
Add `$stdout.flush` before the sleep.  Without the `flush`, the pre-pause output was displayed **after** the pause.